### PR TITLE
docs: add documentation for adding terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To manually check your documentation with Vale rules use the following steps:
 3. Run Vale with the configuration file `vale.ini` from this repository for testing your documentation source files: 
   
     ```shell
-    vale --config ~/praecepta/vale.ini ~/product/docs/
+    vale --config ~/documentation-style-guide/vale.ini ~/product/docs/
     ```
 
 For automation, see the [Canonical Style GitHub action](#the-canonical-style-github-action).
@@ -34,7 +34,7 @@ Anyone is welcome to submit a PR to add additional rules. However, no additions 
 
 For a reference on rule syntax, see the Vale [documentation on Styles][Vale styles].
 
-If you are completely new to developing Vale rules, see this [introductory guide](https://github.com/canonical/praecepta/blob/8c7fee862b2258c692439ef430198e393bdc30c4/getting-started.md). 
+If you are completely new to developing Vale rules, see this [introductory guide](https://github.com/canonical/documentation-style-guide/blob/8c7fee862b2258c692439ef430198e393bdc30c4/getting-started.md). 
 
 ### Using the rules
 
@@ -63,7 +63,7 @@ jobs:
         - name: Checkout repo to runner
           uses: actions/checkout@v3
         - name: Install styles
-          uses: canonical/praecepta@main
+          uses: canonical/documentation-style-guide@main
         - name: Run Vale tests
           uses: errata-ai/vale-action@reviewdog
           with:
@@ -89,12 +89,12 @@ There are times when it is useful to be able to manually run Vale from a termina
 
 1. **Clone the repository**
    ```
-   git clone https://github.com/canonical/praecepta.git
+   git clone https://github.com/canonical/documentation-style-guide.git
    ```
 2. **Set environment variables**
    ```
-   export VALE_CONFIG_PATH=~/praecepta/.vale.ini
-   export VALE_STYLES_PATH=~/praecepta/styles
+   export VALE_CONFIG_PATH=~/documentation-style-guide/.vale.ini
+   export VALE_STYLES_PATH=~/documentation-style-guide/styles
    ```
    Note: this assumes you cloned the repo directly to your home directory - adjust these paths if necessary.
 3. **Confirm configuration**

--- a/adding-dictionary-terms.md
+++ b/adding-dictionary-terms.md
@@ -6,7 +6,7 @@ The first thing to look at when thinking about adding a term to the dictionary, 
 * Command references and project-specific terms that are not used widely outside of a given context, should be added to a project's local custom wordlist.
 * Words that are currently flagged by the spelling check, but exist in a dictionary (or are accepted modern terminology) should be added to the dictionary in this repository.
 
-Let's consider adding the term `rebasing` to the dictionary. This term should be added to the dictionary, but where do we start?
+Let's consider adding the term `rebasing` to the dictionary. Where do we start?
 
 ## Dictionary overview
 

--- a/adding-dictionary-terms.md
+++ b/adding-dictionary-terms.md
@@ -1,36 +1,24 @@
 # Adding dictionary terms
 
-The first thing to look at when thinking about adding a term to the dictionary,
-is to consider what that word is and where it should go.
+The first thing to look at when thinking about adding a term to the dictionary, is to consider what that word is and where it should go.
 
-* Product names should not be added to the dictionary, they should be added to
-the vocabulary list in this repository.
-* Command references and project specific terms that are not used widely outside
-of a given context, should be added to a project's local custom wordlist.
-* Words that are currently flagged by the spelling check, but exist in a
-dictionary (or are accepted modern terminology) should be added to the dictionary
-in this repository.
+* Product names should not be added to the dictionary, they should be added to the vocabulary list in this repository.
+* Command references and project specific terms that are not used widely outside of a given context, should be added to a project's local custom wordlist.
+* Words that are currently flagged by the spelling check, but exist in a dictionary (or are accepted modern terminology) should be added to the dictionary in this repository.
 
 Let's consider adding the term `rebasing` to the dictionary. This term should be added to the dictioanry, but where do we start?
 
 ## Dictionary overview
 
-Vale relies on Hunspell dictionaries for spelling functionality. Hunspell
-dictionaries consist of two files, a `.dic` file containing a list of
-words, and a `.aff` file which essentially contains structures of prefixes and
-suffixes.
+Vale relies on Hunspell dictionaries for spelling functionality. Hunspell dictionaries consist of two files, a `.dic` file containing a list of words, and a `.aff` file which essentially contains structures of prefixes and suffixes.
 
-A word defined in the `en_US.dic` file can be appended with a structure to
-indicate accepted variants as declared in the `en_US.aff` file.
+A word defined in the `en_US.dic` file can be appended with a structure to indicate accepted variants as declared in the `en_US.aff` file.
 
-Knowing that the system uses core words and affixes, the term `rebase` can be
-split into `re` and `base`.
+Knowing that the system uses core words and affixes, the term `rebase` can be split into `re` and `base`.
 
 ## Affix file
 
-The `en_US.aff` file contains some structures that define how a prefix or suffix
-functions for given words. If we look for the affix we need, `re`, we find that
-in this block:
+The `en_US.aff` file contains some structures that define how a prefix or suffix functions for given words. If we look for the affix we need, `re`, we find that in this block:
 
 ```
 PFX A Y 1
@@ -78,8 +66,7 @@ We could just add `A`, to make `base/ACDRSLTG`, but that might make for some str
 
 ## Understanding existing terms
 
-Looking at how `base` is currently defined, we need to understand the terms
-currently provided by this structure, and what a modification would do.
+Looking at how `base` is currently defined, we need to understand the terms currently provided by this structure, and what a modification would do.
 
 ```
 base/CDRSLTG

--- a/adding-dictionary-terms.md
+++ b/adding-dictionary-terms.md
@@ -1,0 +1,152 @@
+# Adding dictionary terms
+
+The first thing to look at when thinking about adding a term to the dictionary,
+is to consider what that word is and where it should go.
+
+* Product names should not be added to the dictionary, they should be added to
+the vocabulary list in this repository.
+* Command references and project specific terms that are not used widely outside
+of a given context, should be added to a project's local custom wordlist.
+* Words that are currently flagged by the spelling check, but exist in a
+dictionary (or are accepted modern terminology) should be added to the dictionary
+in this repository.
+
+Let's consider adding the term `rebasing` to the dictionary. This term should be added to the dictioanry, but where do we start?
+
+## Dictionary overview
+
+Vale relies on Hunspell dictionaries for spelling functionality. Hunspell
+dictionaries consist of two files, a `.dic` file containing a list of
+words, and a `.aff` file which essentially contains structures of prefixes and
+suffixes.
+
+A word defined in the `en_US.dic` file can be appended with a structure to
+indicate accepted variants as declared in the `en_US.aff` file.
+
+Knowing that the system uses core words and affixes, the term `rebase` can be
+split into `re` and `base`.
+
+## Affix file
+
+The `en_US.aff` file contains some structures that define how a prefix or suffix
+functions for given words. If we look for the affix we need, `re`, we find that
+in this block:
+
+```
+PFX A Y 1
+PFX A   0     re         .
+```
+
+We need to break down exactly what this block means. First, consider the
+structure as a table:
+
+| PFX | A | Y | 1 |    |     |
+|-----|---|---|---|----|-----|
+| PFX | A |   | 0 | re |  .  |
+
+Each block has a header row, and then content rows following it. In this case there is a header row, and a single content row. The header row always contains four columns, and the first two columns are shared for the entry. The content row contains six columns, with an empty column in the third position.
+
+The first column indicates if this indicates a prefix (`PFX`) or suffix (`SFX`). In this case, it is a prefix.
+
+The second column indicates the letter used to represent this structure in the dictionary file. In this case, it is the letter `A`.
+
+The third column, with content only in the header row, is the combinable flag which indicates if this structure can be used in conjunction with other structures, or if it is dealt with separately. In this case, this prefix can be used in conjunction with other structures - meaning that this prefix can be used with suffixes that also have a `Y` in this column.
+
+The title row's fourth column indicates the number of entries in the table, in this case a single entry.
+
+The content row's fourth column indicates if a letter is replaced by the affix and what that letter is. In this case, no letter is replaced.
+
+The content row's fifth column indicates the letters used by the affix. In this case, the leters `re` are used.
+
+The content row's sixth column provides a regex structure of letters used to understand if this row applies to a given word. In this case, as a single content row is used, it applies to all words.
+
+So, in this example, the prefix `re` is defined and provided by the letter `A` when used in the dictionary file.
+
+## Dictionary file
+
+Each line in the dictionary provides a different word base, which may also define affixes that may be used with that word using a forward slash `/`.
+
+So we want to add `base/A` to indicate base can be used with the prefix `re`.
+
+However, `base` is already defined in the dictionary file:
+
+```
+base/CDRSLTG
+```
+
+We could just add `A`, to make `base/ACDRSLTG`, but that might make for some strange terms. Remember that `re` can be combined with other affixes, if it wasn't able to be combined we could just add the affix letter and leave it here.
+
+## Understanding existing terms
+
+Looking at how `base` is currently defined, we need to understand the terms
+currently provided by this structure, and what a modification would do.
+
+```
+base/CDRSLTG
+```
+
+Looking at the affix file, the letter C can be found by looking for `FX C` (as all affixes are provided in this pattern, prefix or suffix). So, looking at `C`:
+
+```
+PFX C Y 1
+PFX C   0     de          .
+```
+
+This shows `C` provides the prefix `de` which, despite being having a positive combination flag, cannot be used in conjunction with another prefix. So, `C` does not cause issues with the `A` affix we want to add.
+
+Looking at `D`:
+
+```
+SFX D Y 4
+SFX D   0     d          e
+SFX D   y     ied        [^aeiou]y
+SFX D   0     ed         [^ey]
+SFX D   0     ed         [aeiou]y
+```
+
+This shows that `D` provides the suffix `d`, `ied`, and `ed` in different contexts. The last column defines a regex structure that dictates which suffix applies to which words. In our case, with `base` the last letter is `e` which means the suffix that applies in this case is `d`.
+
+It is worth noting that, if our word ended with `[^aeiou]y`, the `y` at the end of our word would be removed before `ied` was added. This is indicated by the fourth column containing `y`.
+
+This suffix is combinable, so if we consider adding `A`, then the word `rebased` would be added to the dictionary. This is a term we also want to accept.
+
+Looking at `R`:
+
+```
+SFX R Y 4
+SFX R   0     r          e
+SFX R   y     ier        [^aeiou]y
+SFX R   0     er         [aeiou]y
+SFX R   0     er         [^ey]
+```
+
+This shows that `R` provides the suffix `r`, `ier`, or `er` in different contexts. The last column defines a regex structure that dictates which suffix applies to which words. In our case, with `base` the last letter is `e` which means the suffix that applies in this case is `r`.
+
+This suffix is combinable, so if we consider adding `A`, then the word `rebaser` would be added to the dictionary.
+
+This word lies in a grey area, where it *could* be a word we want added to the dictionary, but it would be limited use, and a small edge case. We are adding an action, do we need to refer to the party that does the action in this way? Because of the grey area, this should be raised with the Technical Author team, but for now we will decide that this shouldn't be added to the dictionary.
+
+This means we can't just add `A` to the existing affixes on `base`.
+
+A short summary of the additional affixes:
+
+* `S` provides `-s`, and is combinable, giving `rebases`. This would not be blocking.
+* `L` provides `-ment`, and is combinable, giving `rebasement`. This would be blocking.
+* `T` provides `-st`, and is not combinable. This would not be blocking.
+* `G` provides `-ing`, replaces `e` at the end of a word, and is combinable, giving `rebasing`. This is not blocking.
+
+## Adding a new term
+
+If we cannot just add to the existing `base`, what's the best way to add this new word?
+
+We could add `base/A`, or we could add `rebase`. Both options are acceptable. For our purposes, `rebase` is the core word, so it's better for us to add `rebase` with some relevant affixes.
+
+So, considering the existing forms of `base`, what are the affixes we should use with `rebase`?
+
+We can drop any prefixes, like `C`, otherwise we would get `derebasing`.
+
+We can drop any blocking affixes from the above analysis, like `R` and `L`, which would give us `rebaser` and `rebasement`.
+
+We can drop any non-blocking affixes that weren't combinable but don't make sense, like `T`, which would give us `rebasest`.
+
+We are then left with `D`, `S`, `G`, so we will add `rebase/DSG` to the dictionary in the approrpriate line in alphabetical order.

--- a/adding-dictionary-terms.md
+++ b/adding-dictionary-terms.md
@@ -6,7 +6,7 @@ The first thing to look at when thinking about adding a term to the dictionary, 
 * Command references and project-specific terms that are not used widely outside of a given context, should be added to a project's local custom wordlist.
 * Words that are currently flagged by the spelling check, but exist in a dictionary (or are accepted modern terminology) should be added to the dictionary in this repository.
 
-Let's consider adding the term `rebasing` to the dictionary. This term should be added to the dictioanry, but where do we start?
+Let's consider adding the term `rebasing` to the dictionary. This term should be added to the dictionary, but where do we start?
 
 ## Dictionary overview
 

--- a/adding-dictionary-terms.md
+++ b/adding-dictionary-terms.md
@@ -3,7 +3,7 @@
 The first thing to look at when thinking about adding a term to the dictionary, is to consider what that word is and where it should go.
 
 * Product names should not be added to the dictionary, they should be added to the vocabulary list in this repository.
-* Command references and project specific terms that are not used widely outside of a given context, should be added to a project's local custom wordlist.
+* Command references and project-specific terms that are not used widely outside of a given context, should be added to a project's local custom wordlist.
 * Words that are currently flagged by the spelling check, but exist in a dictionary (or are accepted modern terminology) should be added to the dictionary in this repository.
 
 Let's consider adding the term `rebasing` to the dictionary. This term should be added to the dictioanry, but where do we start?

--- a/getting-started.md
+++ b/getting-started.md
@@ -38,7 +38,7 @@ To develop a rule, you don't have to worry about setting up a particular environ
 First, clone the repository if you haven't already.
 
 ```shell
-git clone git@github.com:canonical/praecepta.git
+git clone git@github.com:canonical/documentation-style-guide.git
 ```
 
 Each rule is one file in the `styles/Canonical` directory. To create a new rule, add a `.yml` file and name it according to the convention you see in the other files: `000-Subject-brief-description.yml`.
@@ -100,11 +100,11 @@ The single quotes indicate the beginning and end of the regex, and the `.*?` qua
 
 Create a file in the root directory of the repository and fill it with text that you expect your rule to catch. It can be in any text format (`.txt`, `.md`, `.rst`...)
 
-Besides the text file, the `vale` command needs a `vale.ini` config file. This file already exists in the root folder `praecepta/`. Vale will automatically find the `vale.ini` if you run the command in the same directory.
+Besides the text file, the `vale` command needs a `vale.ini` config file. This file already exists in the root folder `documentation-style-guide/`. Vale will automatically find the `vale.ini` if you run the command in the same directory.
 
 ### Test all rules
 
-To apply all the rules inside `styles/Canonical` at the same time, run `vale <file>` in the root directory `praecepta/`.
+To apply all the rules inside `styles/Canonical` at the same time, run `vale <file>` in the root directory `documentation-style-guide/`.
 
 For example:
 
@@ -127,7 +127,7 @@ This edit would look similar to the snippet below:
 Canonical.000-My-Rule = YES
 ```
 
-Once it is saved, you can run the command `vale <file>` in the root directory `praecepta/`.
+Once it is saved, you can run the command `vale <file>` in the root directory `documentation-style-guide/`.
 
 For example:
 
@@ -135,7 +135,7 @@ For example:
 vale test.md
 ```
 
-in the root directory `praecepta/`.
+in the root directory `documentation-style-guide/`.
 
 ### Resources
 

--- a/styles/config/dictionaries/en_US.dic
+++ b/styles/config/dictionaries/en_US.dic
@@ -60631,6 +60631,7 @@ reauthorization
 reave/GDRS
 reawake
 Reba/M
+rebase/DSG
 rebaptise
 rebaptism
 rebaptize


### PR DESCRIPTION
* Adds a tutorial for how to add terms to the dictionary
* Updates internal repo references 
* "Rebasing" to be added to dictionary.

`/A` is "re-"
`/G` is "-ing" (already exists)

Current term is: base/CDRSLTG

`/C` is "de-"
`/D` is "-d"
`/R` is "-r"
`/S` is "-s"
`/L` is "-ment"
`/T` is "-st"
`/G` is "-ing"

Adding `/A` would be incompatible ("rebaser(?)", "rebasement", "rebasest")

Instead we add `rebase/DSG`, for "rebased", "rebases", "rebasing".