### PR TITLE
fix InfluxDB casing in vocabulary

### DIFF
--- a/styles/config/vocabularies/Canonical/accept.txt
+++ b/styles/config/vocabularies/Canonical/accept.txt
@@ -134,7 +134,7 @@ IHV
 Imagecraft
 Indico
 Infiniband
-Influxdb
+InfluxDB
 init
 IOV
 IPMI


### PR DESCRIPTION
There was a mismatch between "Influxdb" in the accept.txt file,
and "InfluxDB" styles/Canonical/005-Industry-product-names.yml file.
