### PR TITLE
Update index.md to remove a typo in Hyperlinks section

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -813,7 +813,7 @@ Inform the user the link is external to the current doc set by specifying the so
 If clicking the link performs an action, like downloading a file, link the
 entire action in the sentence.
 
-- Use: `First, [download `file.zip`](file.zip)`
+- Use: `First, [download file.zip](file.zip)`
 - Avoid: `First, download the [file](file.zip)`
 
 ## FAQs


### PR DESCRIPTION
The Hyperlinks section of the style guide had an extra set of backticks around file.zip in the example, which ended up missing a blank space between the words "download" and "file.zip", as seen below:

<img width="737" height="113" alt="изображение" src="https://github.com/user-attachments/assets/0b57e2c3-72c5-4c65-8dc6-2d335079fb8b" />


I corrected the typo by removing extraneous backticks.