### PR TITLE
docs: add allowlist as accepted word

### DIFF
--- a/styles/config/vocabularies/Canonical/accept.txt
+++ b/styles/config/vocabularies/Canonical/accept.txt
@@ -12,6 +12,7 @@ ACLs
 ADB
 ADSys
 AKS
+allowlist
 AMC
 amd
 AMS


### PR DESCRIPTION
To prevent vale fail check because allowlist is not accepted.

allowlist (formerly known as a whitelist) is a security mechanism that explicitly defines a set of entities (e.g., IP addresses, domains, users, or applications) that are permitted to access or perform actions within the cluster, while implicitly denying access to all others.